### PR TITLE
Fix rotation offset not being applied correctly

### DIFF
--- a/SmoothCamPlus/AffinityPatches/SmoothCameraPatch.cs
+++ b/SmoothCamPlus/AffinityPatches/SmoothCameraPatch.cs
@@ -20,21 +20,19 @@ namespace SmoothCamPlus.AffinityPatches
         {
             if (!____thirdPersonEnabled)
             {
-                // Idk how to math, aaa.
-                var customPosition = new Vector3(
-                    ____mainCamera.position.x + _config.PositionX,
-                    ____mainCamera.position.y + _config.PositionY,
-                    ____mainCamera.position.z + _config.PositionZ
-                );
-                var customRotation = new Quaternion(
-                    ____mainCamera.rotation.x + _config.RotationX,
-                    ____mainCamera.rotation.y + _config.RotationY,
-                    ____mainCamera.rotation.z + _config.RotationZ,
-                    ____mainCamera.rotation.w + _config.RotationW
-                );
+                var mainCameraPosition = ____mainCamera.position;
+                var mainCameraRotation = ____mainCamera.rotation;
 
-                var position = Vector3.Lerp(__instance.transform.position, customPosition, Time.deltaTime * ____positionSmooth);
-                var rotation = Quaternion.Slerp(__instance.transform.rotation, customRotation, Time.deltaTime * ____rotationSmooth);
+                var positionOffset = new Vector3(_config.PositionX, _config.PositionY, _config.PositionZ);
+                mainCameraPosition += positionOffset;
+
+                var rotationOffset = new Vector3(_config.RotationX, _config.RotationY, _config.RotationZ);
+                var eulerAngles = mainCameraRotation.eulerAngles;
+                eulerAngles += rotationOffset;
+                mainCameraRotation.eulerAngles = eulerAngles;
+
+                var position = Vector3.Lerp(__instance.transform.position, mainCameraPosition, Time.deltaTime * ____positionSmooth);
+                var rotation = Quaternion.Slerp(__instance.transform.rotation, mainCameraRotation, Time.deltaTime * ____rotationSmooth);
 
                 __instance.transform.SetPositionAndRotation(position, rotation);
 

--- a/SmoothCamPlus/Config.cs
+++ b/SmoothCamPlus/Config.cs
@@ -13,6 +13,5 @@ namespace SmoothCamPlus
         public virtual float RotationX { get; set; }
         public virtual float RotationY { get; set; }
         public virtual float RotationZ { get; set; }
-        public virtual float RotationW { get; set; }
     }
 }

--- a/SmoothCamPlus/UI/SCPSettingsView.cs
+++ b/SmoothCamPlus/UI/SCPSettingsView.cs
@@ -52,13 +52,6 @@ namespace SmoothCamPlus.UI
             set => _config.RotationZ = value;
         }
 
-        [UIValue("rotation-w")]
-        protected float RotationW
-        {
-            get => _config.RotationW;
-            set => _config.RotationW = value;
-        }
-
         [Inject]
         public void Construct(Config config)
         {

--- a/SmoothCamPlus/Views/settings-view.bsml
+++ b/SmoothCamPlus/Views/settings-view.bsml
@@ -10,11 +10,10 @@
 
     <vertical spacing='-10'>
         <text text='Rotation' font-size='12' align='Center' />
-        <horizontal spacing='2' pref-width='180'>
-            <increment-setting text='X' value='rotation-x' apply-on-change='true' min='-100' max='100' increment='.05' />
-            <increment-setting text='Y' value='rotation-y' apply-on-change='true' min='-100' max='100' increment='.05' />
-            <increment-setting text='Z' value='rotation-z' apply-on-change='true' min='-100' max='100' increment='.05' />
-            <increment-setting text='W' value='rotation-w' apply-on-change='true' min='-100' max='100' increment='.05' />
+        <horizontal spacing='2' pref-width='135'>
+            <increment-setting text='X' value='rotation-x' apply-on-change='true' min='-180' max='180' increment='1' />
+            <increment-setting text='Y' value='rotation-y' apply-on-change='true' min='-180' max='180' increment='1' />
+            <increment-setting text='Z' value='rotation-z' apply-on-change='true' min='-180' max='180' increment='1' />
         </horizontal>
     </vertical>
 </vertical>


### PR DESCRIPTION
A `Quaternion` is close to impossible to understand for humans, so setting the right values in the config would also be impossible for the user. Instead, we set `eulerAngles` to apply an angle to the camera, which is much easier to work with.